### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/fbcomment.php
+++ b/syntax/fbcomment.php
@@ -38,13 +38,13 @@ class syntax_plugin_fbsp_fbcomment extends DokuWiki_Syntax_Plugin {
 //        $this->Lexer->addExitPattern('</FIXME>','plugin_fbsp_fbcomment');
 //    }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array();
 
         return $data;
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
 			$renderer->doc .= "<html>
 <div id=\"fb-root\"></div>

--- a/syntax/fblike.php
+++ b/syntax/fblike.php
@@ -38,13 +38,13 @@ class syntax_plugin_fbsp_fblike extends DokuWiki_Syntax_Plugin {
 //        $this->Lexer->addExitPattern('</FIXME>','plugin_fbsp_fblike');
 //    }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array();
 
         return $data;
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
 			$renderer->doc .= "<html>
 <div id=\"fb-root\"></div>


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
